### PR TITLE
unittest checks st_bug() and other improvement

### DIFF
--- a/src/atomic/Makefile
+++ b/src/atomic/Makefile
@@ -1,7 +1,8 @@
 
+# src       = atomic.c
+# target    = atomic.a
 
 test_exec = test_atomic
-target    = atomic.a
 
 BASE_DIR ?= $(CURDIR)/..
 include $(BASE_DIR)/def.mk

--- a/src/bitmap/Makefile
+++ b/src/bitmap/Makefile
@@ -2,6 +2,8 @@
 src       = bitmap.c
 target    = bitmap.a
 
+deps      = util
+
 test_exec = test_bitmap
 
 BASE_DIR ?= $(CURDIR)/..

--- a/src/gc/Makefile
+++ b/src/gc/Makefile
@@ -2,8 +2,17 @@
 src       = gc.c
 target    = gc.a
 libs      = pthread rt
-deps      = robustlock pagepool rbtree array\
-            region slab bitmap table str
+deps      = \
+	    table      \
+	    pagepool   \
+	    rbtree     \
+	    region     \
+	    robustlock \
+	    slab       \
+	    bitmap     \
+	    array      \
+	    str        \
+	    util       \
 
 test_exec = test_gc
 

--- a/src/hash/Makefile
+++ b/src/hash/Makefile
@@ -2,6 +2,9 @@
 src = crc32.c
 target = hash.a
 
+deps = \
+       util \
+
 test_exec = test_hash
 
 BASE_DIR ?= $(CURDIR)/..

--- a/src/hash/test_hash.c
+++ b/src/hash/test_hash.c
@@ -21,7 +21,7 @@ int get_fib_variance(enum fib_size_e fib_size)
     int n_bucket = 256;
     int buckets[n_bucket];
     int i;
-    uint64_t hash;
+    uint64_t hash = 0;
 
     for (i = 0; i < n_bucket; i++) {
         buckets[i] = 0;
@@ -40,6 +40,9 @@ int get_fib_variance(enum fib_size_e fib_size)
                 break;
             case fib64:
                 hash = fib_hash64(i) % n_bucket;
+                break;
+            default:
+                st_bug("unknown fib_size");
                 break;
         }
         buckets[(int)hash] += 1;

--- a/src/inc/bit.h
+++ b/src/inc/bit.h
@@ -11,10 +11,10 @@
 
 #define st_bit_clz_positive_int_(i) _Generic(                                 \
         (i),                                                                  \
-        unsigned int:       __builtin_clz(i),                                 \
-        unsigned long:      __builtin_clzl(i),                                \
-        unsigned long long: __builtin_clzll(i)                                \
-)
+        unsigned int:       __builtin_clz,                                    \
+        unsigned long:      __builtin_clzl,                                   \
+        unsigned long long: __builtin_clzll                                   \
+)(i)
 
 
 /**
@@ -62,9 +62,9 @@
  */
 #define st_bit_cnt1(n) _Generic(                                              \
     (n),                                                                      \
-    unsigned int:       __builtin_popcount(n),                                \
-    unsigned long:      __builtin_popcountl(n),                               \
-    unsigned long long: __builtin_popcountll(n)                               \
-)
+    unsigned int:       __builtin_popcount,                                   \
+    unsigned long:      __builtin_popcountl,                                  \
+    unsigned long long: __builtin_popcountll                                  \
+)(n)
 
 #endif /* INC_BIT_H */

--- a/src/inc/fmt.h
+++ b/src/inc/fmt.h
@@ -3,7 +3,7 @@
 
 #include <inttypes.h>
 
-#define st_fmt_of(a, v, b) _Generic((v),                                      \
+#define st_fmt_wrap(a, v, b) _Generic((v),                                    \
     char:      a "%c"      b ,                                                \
     int8_t:    a "%"PRIi8  b ,                                                \
     int16_t:   a "%"PRIi16 b ,                                                \
@@ -16,6 +16,29 @@
     void*:     a "%p"      b ,                                                \
     default:   a "%p"      b                                                  \
 )
+
+
+/* In c standards: char, signed char and unsidned char are 3 distinct types! */
+
+#define st_fmt_map_                                                           \
+                 char      :   "%c",                                          \
+        signed   char      :   "%c",                                          \
+                 short     :  "%hd",                                          \
+                 int       :   "%d",                                          \
+                 long      :  "%ld",                                          \
+                 long long : "%lld",                                          \
+        unsigned char      :   "%u",                                          \
+        unsigned short     :  "%hu",                                          \
+        unsigned int       :   "%u",                                          \
+        unsigned long      :  "%lu",                                          \
+        unsigned long long : "%llu",                                          \
+                 float     :   "%f",                                          \
+                 double    :   "%f",                                          \
+                 void*     :   "%p"
+
+#define st_fmt_of(v) _Generic((v), st_fmt_map_, default: "%p")
+
+#define st_fmt_strict_of(v) _Generic((v), st_fmt_map_ )
 
 
 #endif /* inc_fmt_ */

--- a/src/inc/inc.h
+++ b/src/inc/inc.h
@@ -6,5 +6,6 @@
 #include "inc/log.h"
 #include "inc/util.h"
 #include "inc/types.h"
+#include "inc/callback.h"
 
 #endif

--- a/src/inc/log.h
+++ b/src/inc/log.h
@@ -12,7 +12,7 @@
 #   define dd( _fmt, ... )   st_log_printf(_fmt "\n", "[DEBUG]", ##__VA_ARGS__)
 #   define dlog( _fmt, ... ) st_log_printf(_fmt, "[DEBUG]", ##__VA_ARGS__)
 #   define ddv( _fmt, ... )  st_stderr_printf( _fmt, ##__VA_ARGS__)
-#   define ddx(n)            st_stderr_printf(st_fmt_of(#n "=", n, "\n"), n)
+#   define ddx(n)            st_stderr_printf(st_fmt_wrap(#n "=", n, "\n"), n)
 #else
 #   define dd( _fmt, ... )
 #   define dlog( _fmt, ... )

--- a/src/inc/util.h
+++ b/src/inc/util.h
@@ -67,7 +67,7 @@
             }                                                                 \
         } while (0);
 
-#define st_bug(_fmt, ...) raise(SIGABRT)
+#define st_bug(_fmt, ...) st_util_bughandler_()
 
 
 #define st_arg1(a, ...) a
@@ -177,10 +177,10 @@
       }                                                                       \
   } while (0)
 
-#define st_assert(expr) do {                                                  \
+#define st_assert(expr, _fmt...) do {                                         \
       if (! (expr)) {                                                         \
-          derr("assertion fail: "#expr);                                      \
-          st_bug("assertion fail: "#expr);                                    \
+          derr("assertion fail: ["#expr"] "_fmt);                             \
+          st_bug("assertion fail: ["#expr"] "_fmt);                           \
       }                                                                       \
   } while (0)
 
@@ -219,5 +219,11 @@ st_free( void* pnt )
     free( pnt );
 }
 #endif
+
+typedef void (*st_util_bughandler_t)();
+
+void st_util_bughandler_raise();
+
+extern st_util_bughandler_t st_util_bughandler_;
 
 #endif /* __INC__UTIL_H__ */

--- a/src/list/Makefile
+++ b/src/list/Makefile
@@ -1,7 +1,11 @@
 
+# src       = list.c
+# target    = list.a
 
 test_exec = test_list
-target    = list.a
+
+deps      = \
+	    util \
 
 BASE_DIR ?= $(CURDIR)/..
 include $(BASE_DIR)/def.mk

--- a/src/pagepool/Makefile
+++ b/src/pagepool/Makefile
@@ -2,7 +2,13 @@
 src       = pagepool.c
 target    = pagepool.a
 test_exec = test_pagepool
-deps      = robustlock array rbtree list region
+deps      = \
+	    array \
+	    rbtree \
+	    region \
+	    robustlock \
+	    util
+
 libs      = rt pthread
 
 BASE_DIR ?= $(CURDIR)/..

--- a/src/rbtree/Makefile
+++ b/src/rbtree/Makefile
@@ -4,5 +4,8 @@ target    = rbtree.a
 
 test_exec = test_rbtree
 
+deps      = \
+	    util \
+
 BASE_DIR ?= $(CURDIR)/..
 include $(BASE_DIR)/def.mk

--- a/src/slab/Makefile
+++ b/src/slab/Makefile
@@ -2,7 +2,14 @@
 src       = slab.c
 target    = slab.a
 libs      = pthread rt
-deps      = robustlock bitmap pagepool rbtree array region
+deps      = \
+	    bitmap \
+	    pagepool \
+	    array \
+	    rbtree \
+	    region \
+	    robustlock \
+	    util \
 
 test_exec = test_slab
 

--- a/src/str/Makefile
+++ b/src/str/Makefile
@@ -1,5 +1,7 @@
 src       = str.c
 target    = str.a
+deps      = \
+	    util \
 
 test_exec = test_str
 

--- a/src/table/Makefile
+++ b/src/table/Makefile
@@ -2,8 +2,17 @@
 src       = table.c
 target    = table.a
 libs      = pthread rt
-deps      = robustlock pagepool rbtree\
-            array region slab bitmap str gc
+deps      = \
+	    robustlock \
+	    pagepool \
+	    rbtree\
+	    array \
+	    region \
+	    slab \
+	    bitmap \
+	    str \
+	    gc \
+	    util \
 
 test_exec = test_table
 

--- a/src/util/Makefile
+++ b/src/util/Makefile
@@ -1,5 +1,5 @@
-# src = util.c
-# target = util.a
+src = util.c
+target = util.a
 
 test_exec = test_util
 

--- a/src/util/test_util.c
+++ b/src/util/test_util.c
@@ -307,4 +307,13 @@ st_test(util, bit_cnt1_before)
  *     foreach
  */
 
+st_test(util, bug_handler)
+{
+    st_util_bughandler_t f = st_util_bughandler_raise;
+    st_ut_eq((void*)f, (void*)st_util_bughandler_);
+
+    st_ut_bug(st_bug(), "st_bug() should make a bug");
+    st_ut_nobug((void)1, "(void)1 should not make a bug");
+}
+
 st_ut_main;

--- a/src/util/util.c
+++ b/src/util/util.c
@@ -1,0 +1,7 @@
+#include "inc/util.h"
+
+void st_util_bughandler_raise() {
+    raise(SIGABRT);
+}
+
+st_util_bughandler_t st_util_bughandler_ = st_util_bughandler_raise;


### PR DESCRIPTION
- Add printf format macro to detect by type
- `st_bug()` handler can be overrided during unittest, for testing assertions about arguments.
- Add util, support runtime `st_bug()` handler.
- unittest add 2 assertion: `st_ut_bug()` and `st_ut_nobug()`.
- Test `st_bug()`.
- Simplify printing in unittest.