### PR TITLE
Shuwen.rbtree

### DIFF
--- a/src/pagepool/pagepool.c
+++ b/src/pagepool/pagepool.c
@@ -102,7 +102,7 @@ static void st_pagepool_init_region(st_pagepool_t *pool, uint8_t *region) {
 static void st_pagepool_add_pages(st_pagepool_t *pool, st_pagepool_page_t *master) {
     st_rbtree_node_t *n;
 
-    n = st_rbtree_search_eq(&pool->free_pages, &master->rbnode);
+    n = st_rbtree_search(&pool->free_pages, &master->rbnode, ST_SIDE_EQ);
 
     if (n == NULL) {
         st_rbtree_insert(&pool->free_pages, &master->rbnode, 1, NULL);

--- a/src/pagepool/pagepool.c
+++ b/src/pagepool/pagepool.c
@@ -222,7 +222,7 @@ static int st_pagepool_get_free_pages(st_pagepool_t *pool, int cnt,
     st_pagepool_page_t tmp = {.compound_page_cnt = cnt};
 
     //find equal or bigger free pages to allocate
-    n = st_rbtree_search_ge(&pool->free_pages, &tmp.rbnode);
+    n = st_rbtree_search(&pool->free_pages, &tmp.rbnode, ST_SIDE_RIGHT_EQ);
     if (n == NULL) {
         return ST_NOT_FOUND;
     }

--- a/src/pagepool/test_pagepool.c
+++ b/src/pagepool/test_pagepool.c
@@ -217,7 +217,7 @@ st_test(pagepool, alloc) {
                                     ST_PAGEPOOL_PAGE_ALLOCATED), "");
 
         tmp.compound_page_cnt = c.remain;
-        st_rbtree_node_t *n = st_rbtree_search_eq(&pool.free_pages, &tmp.rbnode);
+        st_rbtree_node_t *n = st_rbtree_search(&pool.free_pages, &tmp.rbnode, ST_SIDE_EQ);
         st_pagepool_page_t *remain = st_owner(n, st_pagepool_page_t, rbnode);
         st_ut_eq(ST_OK, check_pages(remain, pool.regions_array_data[0], c.remain, ST_PAGEPOOL_PAGE_FREE),
                  "");
@@ -286,7 +286,7 @@ st_test(pagepool, free) {
 
         for (int j = 0; j < c.remain_cnt; j++) {
             tmp.compound_page_cnt = c.remain_pages[j];
-            st_rbtree_node_t *n = st_rbtree_search_eq(&pool.free_pages, &tmp.rbnode);
+            st_rbtree_node_t *n = st_rbtree_search(&pool.free_pages, &tmp.rbnode, ST_SIDE_EQ);
             st_pagepool_page_t *remain = st_owner(n, st_pagepool_page_t, rbnode);
 
             st_ut_ne(NULL, remain, "");
@@ -375,14 +375,14 @@ st_test(pagepool, free_and_alloc) {
 
         for (int j = 0; j < c.remain_cnt; j++) {
             tmp.compound_page_cnt = c.remain_pages[j];
-            st_rbtree_node_t *n = st_rbtree_search_eq(&pool.free_pages, &tmp.rbnode);
+            st_rbtree_node_t *n = st_rbtree_search(&pool.free_pages, &tmp.rbnode, ST_SIDE_EQ);
             st_pagepool_page_t *remain = st_owner(n, st_pagepool_page_t, rbnode);
             st_ut_eq(ST_OK, check_pages(remain, pool.regions_array_data[0], c.remain_pages[j],
                                         ST_PAGEPOOL_PAGE_FREE), "");
         }
 
         tmp.compound_page_cnt = c.not_remain_pages;
-        st_ut_eq(NULL, st_rbtree_search_eq(&pool.free_pages, &tmp.rbnode), "");
+        st_ut_eq(NULL, st_rbtree_search(&pool.free_pages, &tmp.rbnode, ST_SIDE_EQ), "");
     }
 
     free_buf(buf, 655360);
@@ -415,7 +415,7 @@ st_test(pagepool, free_same_page_cnt) {
     }
 
     tmp.compound_page_cnt = 2;
-    st_rbtree_node_t *n = st_rbtree_search_eq(&pool.free_pages, &tmp.rbnode);
+    st_rbtree_node_t *n = st_rbtree_search(&pool.free_pages, &tmp.rbnode, ST_SIDE_EQ);
     st_pagepool_page_t *free_pages = st_owner(n, st_pagepool_page_t, rbnode);
 
     st_ut_eq(pages[0], free_pages, "");
@@ -482,7 +482,7 @@ st_test(pagepool, alloc_in_multi_region) {
     st_ut_eq(10, st_array_current_cnt(&pool.regions), "");
 
     tmp.compound_page_cnt = 5;
-    st_rbtree_node_t *n = st_rbtree_search_eq(&pool.free_pages, &tmp.rbnode);
+    st_rbtree_node_t *n = st_rbtree_search(&pool.free_pages, &tmp.rbnode, ST_SIDE_EQ);
 
     st_pagepool_page_t *free_pages = st_owner(n, st_pagepool_page_t, rbnode);
     st_ut_eq(ST_OK, check_pages(free_pages, pool.regions_array_data[0], 5, ST_PAGEPOOL_PAGE_FREE), "");
@@ -524,7 +524,7 @@ st_test(pagepool, free_in_multi_region) {
         }
 
         tmp.compound_page_cnt = 5;
-        st_rbtree_node_t *n = st_rbtree_search_eq(&pool.free_pages, &tmp.rbnode);
+        st_rbtree_node_t *n = st_rbtree_search(&pool.free_pages, &tmp.rbnode, ST_SIDE_EQ);
         st_pagepool_page_t *free_pages = st_owner(n, st_pagepool_page_t, rbnode);
 
         if (i < 9) {

--- a/src/rbtree/rbtree.c
+++ b/src/rbtree/rbtree.c
@@ -490,13 +490,6 @@ st_rbtree_node_t *st_rbtree_search(st_rbtree_t *tree, st_rbtree_node_t *target, 
     return ler[st_side_strip_eq(expected_side)];
 }
 
-// node maybe not in tree, so need search node.
-st_rbtree_node_t *st_rbtree_search_next(st_rbtree_t *tree, st_rbtree_node_t *node) {
-    /* deprecated */
-    /* TODO if node->sentinel == tree->sentinel, find next with get_next instead of a tree traverse */
-    return st_rbtree_search(tree, node, ST_SIDE_RIGHT);
-}
-
 // node must be in tree, so need search node, just get node next.
 st_rbtree_node_t *st_rbtree_get_next(st_rbtree_t *tree, st_rbtree_node_t *node) {
 

--- a/src/rbtree/rbtree.c
+++ b/src/rbtree/rbtree.c
@@ -490,11 +490,6 @@ st_rbtree_node_t *st_rbtree_search(st_rbtree_t *tree, st_rbtree_node_t *target, 
     return ler[st_side_strip_eq(expected_side)];
 }
 
-st_rbtree_node_t *st_rbtree_search_ge(st_rbtree_t *tree, st_rbtree_node_t *node) {
-    /* deprecated */
-    return st_rbtree_search(tree, node, ST_SIDE_RIGHT_EQ);
-}
-
 // node maybe not in tree, so need search node.
 st_rbtree_node_t *st_rbtree_search_next(st_rbtree_t *tree, st_rbtree_node_t *node) {
     /* deprecated */

--- a/src/rbtree/rbtree.c
+++ b/src/rbtree/rbtree.c
@@ -490,11 +490,6 @@ st_rbtree_node_t *st_rbtree_search(st_rbtree_t *tree, st_rbtree_node_t *target, 
     return ler[st_side_strip_eq(expected_side)];
 }
 
-st_rbtree_node_t *st_rbtree_search_le(st_rbtree_t *tree, st_rbtree_node_t *node) {
-    /* deprecated */
-    return st_rbtree_search(tree, node, ST_SIDE_LEFT_EQ);
-}
-
 st_rbtree_node_t *st_rbtree_search_ge(st_rbtree_t *tree, st_rbtree_node_t *node) {
     /* deprecated */
     return st_rbtree_search(tree, node, ST_SIDE_RIGHT_EQ);

--- a/src/rbtree/rbtree.c
+++ b/src/rbtree/rbtree.c
@@ -442,7 +442,7 @@ int st_rbtree_delete(st_rbtree_t *tree, st_rbtree_node_t *node) {
 
 /* st_rbtree_search(tree, target, ST_SIDE_EQ)      looks for equal node or NULL.
  * st_rbtree_search(tree, target, ST_SIDE_LEFT)    looks for a unequal node on the left to `target`.
- * st_rbtree_search(tree, target, ST_SIDE_LEFT_EQ) looks for equal node or nearset node on the left to `target`.
+ * st_rbtree_search(tree, target, ST_SIDE_LEFT_EQ) looks for equal node or nearest node on the left to `target`.
  */
 st_rbtree_node_t *st_rbtree_search(st_rbtree_t *tree, st_rbtree_node_t *target, int expected_side) {
 
@@ -488,11 +488,6 @@ st_rbtree_node_t *st_rbtree_search(st_rbtree_t *tree, st_rbtree_node_t *target, 
     }
 
     return ler[st_side_strip_eq(expected_side)];
-}
-
-st_rbtree_node_t *st_rbtree_search_eq(st_rbtree_t *tree, st_rbtree_node_t *node) {
-    /* deprecated */
-    return st_rbtree_search(tree, node, ST_SIDE_EQ);
 }
 
 st_rbtree_node_t *st_rbtree_search_le(st_rbtree_t *tree, st_rbtree_node_t *node) {

--- a/src/rbtree/rbtree.h
+++ b/src/rbtree/rbtree.h
@@ -53,7 +53,6 @@ st_rbtree_node_t *st_rbtree_right_most(st_rbtree_t *tree);
 /* Search for a equal node or the nearest node on the <side> to <target> */
 st_rbtree_node_t *st_rbtree_search(st_rbtree_t *tree, st_rbtree_node_t *target, int expected_side);
 
-st_rbtree_node_t *st_rbtree_search_le(st_rbtree_t *tree, st_rbtree_node_t *node);
 st_rbtree_node_t *st_rbtree_search_ge(st_rbtree_t *tree, st_rbtree_node_t *node);
 st_rbtree_node_t *st_rbtree_search_next(st_rbtree_t *tree, st_rbtree_node_t *node);
 st_rbtree_node_t *st_rbtree_get_next(st_rbtree_t *tree, st_rbtree_node_t *node);

--- a/src/rbtree/rbtree.h
+++ b/src/rbtree/rbtree.h
@@ -53,7 +53,6 @@ st_rbtree_node_t *st_rbtree_right_most(st_rbtree_t *tree);
 /* Search for a equal node or the nearest node on the <side> to <target> */
 st_rbtree_node_t *st_rbtree_search(st_rbtree_t *tree, st_rbtree_node_t *target, int expected_side);
 
-st_rbtree_node_t *st_rbtree_search_eq(st_rbtree_t *tree, st_rbtree_node_t *node);
 st_rbtree_node_t *st_rbtree_search_le(st_rbtree_t *tree, st_rbtree_node_t *node);
 st_rbtree_node_t *st_rbtree_search_ge(st_rbtree_t *tree, st_rbtree_node_t *node);
 st_rbtree_node_t *st_rbtree_search_next(st_rbtree_t *tree, st_rbtree_node_t *node);

--- a/src/rbtree/rbtree.h
+++ b/src/rbtree/rbtree.h
@@ -53,7 +53,6 @@ st_rbtree_node_t *st_rbtree_right_most(st_rbtree_t *tree);
 /* Search for a equal node or the nearest node on the <side> to <target> */
 st_rbtree_node_t *st_rbtree_search(st_rbtree_t *tree, st_rbtree_node_t *target, int expected_side);
 
-st_rbtree_node_t *st_rbtree_search_ge(st_rbtree_t *tree, st_rbtree_node_t *node);
 st_rbtree_node_t *st_rbtree_search_next(st_rbtree_t *tree, st_rbtree_node_t *node);
 st_rbtree_node_t *st_rbtree_get_next(st_rbtree_t *tree, st_rbtree_node_t *node);
 

--- a/src/rbtree/rbtree.h
+++ b/src/rbtree/rbtree.h
@@ -53,7 +53,6 @@ st_rbtree_node_t *st_rbtree_right_most(st_rbtree_t *tree);
 /* Search for a equal node or the nearest node on the <side> to <target> */
 st_rbtree_node_t *st_rbtree_search(st_rbtree_t *tree, st_rbtree_node_t *target, int expected_side);
 
-st_rbtree_node_t *st_rbtree_search_next(st_rbtree_t *tree, st_rbtree_node_t *node);
 st_rbtree_node_t *st_rbtree_get_next(st_rbtree_t *tree, st_rbtree_node_t *node);
 
 /** Note:

--- a/src/rbtree/test_rbtree.c
+++ b/src/rbtree/test_rbtree.c
@@ -185,13 +185,6 @@ st_test(rbtree, search) {
 
         /* equal */
 
-        obj = (test_object *)st_rbtree_search_eq(&tree,  &tmp.rb_node);
-        if (c.equal_key == -1) {
-            st_ut_eq(NULL, obj, "");
-        } else {
-            st_ut_eq(c.equal_key, obj->key, "");
-        }
-
         obj = (test_object *)st_rbtree_search(&tree,  &tmp.rb_node, ST_SIDE_EQ);
         if (c.equal_key == -1) {
             st_ut_eq(NULL, obj, "");

--- a/src/rbtree/test_rbtree.c
+++ b/src/rbtree/test_rbtree.c
@@ -196,13 +196,6 @@ st_test(rbtree, search) {
 
         /* greater */
 
-        obj = (test_object *)st_rbtree_search_next(&tree,  &tmp.rb_node);
-        if (c.right_key == -1) {
-            st_ut_eq(NULL, obj, "");
-        } else {
-            st_ut_eq(c.right_key, obj->key, "");
-        }
-
         obj = (test_object *)st_rbtree_search(&tree,  &tmp.rb_node, ST_SIDE_RIGHT);
         if (c.right_key == -1) {
             st_ut_eq(NULL, obj, "");

--- a/src/rbtree/test_rbtree.c
+++ b/src/rbtree/test_rbtree.c
@@ -169,13 +169,6 @@ st_test(rbtree, search) {
 
         /* less equal */
 
-        obj = (test_object *)st_rbtree_search_le(&tree,  &tmp.rb_node);
-        if (c.le_key == -1) {
-            st_ut_eq(NULL, obj, "");
-        } else {
-            st_ut_eq(c.le_key, obj->key, "");
-        }
-
         obj = (test_object *)st_rbtree_search(&tree,  &tmp.rb_node, ST_SIDE_LEFT_EQ);
         if (c.le_key == -1) {
             st_ut_eq(NULL, obj, "");

--- a/src/rbtree/test_rbtree.c
+++ b/src/rbtree/test_rbtree.c
@@ -187,13 +187,6 @@ st_test(rbtree, search) {
 
         /* greater equal */
 
-        obj = (test_object *)st_rbtree_search_ge(&tree,  &tmp.rb_node);
-        if (c.ge_key == -1) {
-            st_ut_eq(NULL, obj, "");
-        } else {
-            st_ut_eq(c.ge_key, obj->key, "");
-        }
-
         obj = (test_object *)st_rbtree_search(&tree,  &tmp.rb_node, ST_SIDE_RIGHT_EQ);
         if (c.ge_key == -1) {
             st_ut_eq(NULL, obj, "");

--- a/src/table/table.c
+++ b/src/table/table.c
@@ -83,7 +83,7 @@ static int st_table_get_element(st_table_t *table, st_str_t key, st_table_elemen
 
     st_table_element_t tmp = {.key = key};
 
-    st_rbtree_node_t *n = st_rbtree_search_eq(&table->elements, &tmp.rbnode);
+    st_rbtree_node_t *n = st_rbtree_search(&table->elements, &tmp.rbnode, ST_SIDE_EQ);
     if (n == NULL) {
         return ST_NOT_FOUND;
     }


### PR DESCRIPTION
去掉rbtree中st_rbtree_search_*的函数,使用st_rbtree_search [#Issues 89](https://github.com/bsc-s2/lua-sharedtable/issues/89)