### PR TITLE
region remap

### DIFF
--- a/src/region/README.md
+++ b/src/region/README.md
@@ -34,6 +34,7 @@ Usage of creating and destroying OSIX-based shared memory space.
 #define PAGES_PER_REGION            1024
 #define REGION_NUM                  10
 #define PAGE_SIZE                   sysconf(_SC_PAGESIZE)
+#define SHM_FN                      "my_shm_fn"
 
 
 int main()
@@ -46,7 +47,7 @@ int main()
     ssize_t length    = data_len + cfg_len;
 
     /** create shm area */
-    int ret = st_region_shm_create(length, (void **)&addr, &shm_fd);
+    int ret = st_region_shm_create(SHM_FN, length, (void **)&addr, &shm_fd);
     if (ret != ST_OK) {
         /** your error handling code */
         exit(1);
@@ -96,7 +97,7 @@ int main()
         exit(5);
     }
 
-    ret = st_region_shm_destroy(shm_fd, addr, length);
+    ret = st_region_shm_destroy(shm_fd, SHM_FN, addr, length);
     if (ret != ST_OK) {
         /** your error handling code */
         exit(6);

--- a/src/region/region.h
+++ b/src/region/region.h
@@ -43,10 +43,17 @@ struct st_region_s {
 
 
 /* create a posix-shared-memory based mapped area */
-int st_region_shm_create(uint32_t length, void **ret_addr, int *ret_shm_fd);
+int
+st_region_shm_create(const char *shm_fn,
+                     uint32_t length,
+                     void **ret_addr,
+                     int *ret_shm_fd);
 
 /* destory posix-shared-memory area */
-int st_region_shm_destroy(int shm_fd, void *addr, uint32_t length);
+int st_region_shm_destroy(int shm_fd,
+                          const char *shm_fn,
+                          void *addr,
+                          uint32_t length);
 
 /* initialize shm reg control block */
 int st_region_init(st_region_t *rcb,

--- a/src/region/region.h
+++ b/src/region/region.h
@@ -55,6 +55,10 @@ int st_region_shm_destroy(int shm_fd,
                           void *addr,
                           uint32_t length);
 
+int st_region_shm_memcpy(const char *shm_fn, void *dst, ssize_t length);
+
+int st_region_shm_mmap(int shm_fd, ssize_t length, void **ret_addr);
+
 /* initialize shm reg control block */
 int st_region_init(st_region_t *rcb,
                    uint8_t     *base_addr,

--- a/src/region/test_region.c
+++ b/src/region/test_region.c
@@ -19,7 +19,8 @@
 #define CONFIG_REGION               10
 #define PAGES_PER_REGION            1024
 #define REGION_NUM                  10
-#define ST_REGION_SHM_OBJ_REAL_PATH "/dev/shm/st_shm_area"
+#define ST_REGION_SHM_FN            "st_shm_area"
+#define ST_REGION_SHM_OBJ_REAL_PATH "/dev/shm/" ST_REGION_SHM_FN
 
 
 /** check if fd represent file described by fpath */
@@ -49,7 +50,10 @@ static void
 test_st_region_shm_create(int *shm_fd, uint8_t **addr, int length)
 {
     *shm_fd = -1;
-    int ret = st_region_shm_create(length, (void **)addr, shm_fd);
+    int ret = st_region_shm_create(ST_REGION_SHM_FN,
+                                   length,
+                                   (void **)addr,
+                                   shm_fd);
 
     st_ut_eq(ST_OK, ret, "st_region_shm_create failed");
     st_ut_ne(MAP_FAILED, addr, "st_region_shm_create set addr wrong");
@@ -60,7 +64,7 @@ test_st_region_shm_create(int *shm_fd, uint8_t **addr, int length)
 static void
 test_st_region_shm_destroy(int shm_fd, uint8_t *addr, int length)
 {
-    int ret = st_region_shm_destroy(shm_fd, addr, length);
+    int ret = st_region_shm_destroy(shm_fd, ST_REGION_SHM_FN, addr, length);
 
     st_ut_eq(ST_OK, ret, "st_region_shm_destroy failed");
 

--- a/src/slab/README.md
+++ b/src/slab/README.md
@@ -48,6 +48,7 @@ typedef struct {
 } setup_info_t;
 
 
+#define SHM_FN                           "my_shm_fn"
 #define PAGE_SIZE                        (1 << 12)
 #define ST_TEST_SLAB_HUGE_OBJ_SIZE       (PAGE_SIZE + 1)
 
@@ -57,7 +58,8 @@ typedef struct {
 static void
 st_slab_setup(setup_info_t *info)
 {
-    int ret = st_region_shm_create(ST_TEST_SLAB_SHARED_SPACE_LENGTH,
+    int ret = st_region_shm_create(SHM_FN,
+                                   ST_TEST_SLAB_SHARED_SPACE_LENGTH,
                                    &info->base,
                                    &info->shm_fd);
     st_assert(ret == ST_OK);
@@ -99,6 +101,7 @@ st_slab_cleanup(setup_info_t *info, int must_ok)
     }
 
     ret = st_region_shm_destroy(info->shm_fd,
+                                SHM_FN,
                                 info->base,
                                 ST_TEST_SLAB_SHARED_SPACE_LENGTH);
     st_assert(ret == ST_OK);

--- a/src/slab/test_slab.c
+++ b/src/slab/test_slab.c
@@ -25,6 +25,7 @@ typedef struct {
 } setup_info_t;
 
 
+#define ST_TEST_SLAB_SHM_FN              "slab_shm_fn"
 #define ST_TEST_SLAB_HUGE_OBJ_SIZE       (st_page_size() + 1)
 #define ST_TEST_SLAB_REGION_CNT          10
 #define ST_TEST_SLAB_SHARED_SPACE_LENGTH (1024 * 1024 * 200)
@@ -46,7 +47,8 @@ typedef struct {
 static void
 st_slab_setup(setup_info_t *info)
 {
-    int ret = st_region_shm_create(ST_TEST_SLAB_SHARED_SPACE_LENGTH,
+    int ret = st_region_shm_create(ST_TEST_SLAB_SHM_FN,
+                                   ST_TEST_SLAB_SHARED_SPACE_LENGTH,
                                    &info->base,
                                    &info->shm_fd);
     st_assert(ret == ST_OK);
@@ -90,6 +92,7 @@ st_slab_cleanup(setup_info_t *info, int must_ok)
     }
 
     ret = st_region_shm_destroy(info->shm_fd,
+                                ST_TEST_SLAB_SHM_FN,
                                 info->base,
                                 ST_TEST_SLAB_SHARED_SPACE_LENGTH);
     st_assert(ret == ST_OK);

--- a/src/table/test_table.c
+++ b/src/table/test_table.c
@@ -11,6 +11,7 @@
 #include <time.h>
 #include <stdlib.h>
 
+#define TEST_TABLE_SHM_FN "test_table_shm_fn"
 #define TEST_POOL_SIZE 100 * 1024 * 4096
 
 #ifdef _SEM_SEMUN_UNDEFINED
@@ -57,7 +58,8 @@ static ssize_t remain_element_cnt(st_table_pool_t *pool, uint64_t element_size) 
 static st_table_pool_t *alloc_table_pool(int* shm_fd) {
     st_table_pool_t *pool;
 
-    int ret = st_region_shm_create(TEST_POOL_SIZE,
+    int ret = st_region_shm_create(TEST_TABLE_SHM_FN,
+                                   TEST_POOL_SIZE,
                                    (void **)&pool,
                                    shm_fd);
     st_assert(ret == ST_OK);
@@ -98,6 +100,7 @@ static void free_table_pool(st_table_pool_t *pool, int shm_fd) {
     st_assert(ret == ST_OK);
 
     ret = st_region_shm_destroy(shm_fd,
+                                TEST_TABLE_SHM_FN,
                                 (void *)pool,
                                 TEST_POOL_SIZE);
     st_assert(ret == ST_OK);


### PR DESCRIPTION
在st_region_shm_create和st_region_shm_destroy中添加共享内存文件名参数。

添加st_region_shm_memcpy用来加载在共享内存中的配置信息。
添加st_region_shm_mmap接口，通过remap共享内存区域。